### PR TITLE
Adds method to configure HTML rendering options on Redcarpet

### DIFF
--- a/lib/generators/markdown_rails/install/templates/app/markdown/application_markdown.rb
+++ b/lib/generators/markdown_rails/install/templates/app/markdown/application_markdown.rb
@@ -21,6 +21,15 @@ class ApplicationMarkdown < MarkdownRails::Renderer::Rails
   #   :turbo_frame_tag,
   # to: :helpers
 
+  # These flags control HTML rendering options in the Redcarpet renderer.
+  # Details here: https://github.com/vmg/redcarpet?tab=readme-ov-file#darling-i-packed-you-a-couple-renderers-for-lunch
+  # These options impact the parsing and transformation of HTML, so be careful if
+  # this renderer handles user inputs.
+  #
+  # def render_options
+  #   [:with_toc_data]
+  # end
+
   # These flags control features in the Redcarpet renderer, which you can read
   # about at https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
   # Make sure you know what you're doing if you're using this to render user inputs.
@@ -32,7 +41,7 @@ class ApplicationMarkdown < MarkdownRails::Renderer::Rails
   def image(link, title, alt)
     url = URI(link)
     case url.host
-    when "www.youtube.com"
+    when 'www.youtube.com'
       youtube_tag url, alt
     else
       super
@@ -40,15 +49,16 @@ class ApplicationMarkdown < MarkdownRails::Renderer::Rails
   end
 
   private
-    # This is provided as an example; there's many more YouTube URLs that this wouldn't catch.
-    def youtube_tag(url, alt)
-      embed_url = "https://www.youtube-nocookie.com/embed/#{CGI.parse(url.query).fetch("v").first}"
-      content_tag :iframe,
-        src: embed_url,
-        width: 560,
-        height: 325,
-        allow: "encrypted-media; picture-in-picture",
-        allowfullscreen: true \
-          do alt end
-    end
+
+  # This is provided as an example; there's many more YouTube URLs that this wouldn't catch.
+  def youtube_tag(url, alt)
+    embed_url = "https://www.youtube-nocookie.com/embed/#{CGI.parse(url.query).fetch('v').first}"
+    content_tag :iframe,
+                src: embed_url,
+                width: 560,
+                height: 325,
+                allow: 'encrypted-media; picture-in-picture',
+                allowfullscreen: true \
+        do alt end
+  end
 end

--- a/lib/generators/markdown_rails/install/templates/config/initializers/markdown.rb
+++ b/lib/generators/markdown_rails/install/templates/config/initializers/markdown.rb
@@ -1,11 +1,5 @@
 # Restart the server to see changes made to this file.
 
-MarkdownRails::Renderer.configuration do |config|
-  # This is a sample HTML rendering option
-  # More details: https://github.com/vmg/redcarpet?tab=readme-ov-file#darling-i-packed-you-a-couple-renderers-for-lunch
-  config.render_options = [:with_toc_data]
-end
-
 # Setup markdown stacks to work with different template handler in Rails.
 MarkdownRails.handle :md, :markdown do
   ApplicationMarkdown.new

--- a/lib/generators/markdown_rails/install/templates/config/initializers/markdown.rb
+++ b/lib/generators/markdown_rails/install/templates/config/initializers/markdown.rb
@@ -1,5 +1,11 @@
 # Restart the server to see changes made to this file.
 
+MarkdownRails::Renderer.configuration do |config|
+  # This is a sample HTML rendering option
+  # More details: https://github.com/vmg/redcarpet?tab=readme-ov-file#darling-i-packed-you-a-couple-renderers-for-lunch
+  config.render_options = [:with_toc_data]
+end
+
 # Setup markdown stacks to work with different template handler in Rails.
 MarkdownRails.handle :md, :markdown do
   ApplicationMarkdown.new

--- a/lib/markdown-rails.rb
+++ b/lib/markdown-rails.rb
@@ -9,24 +9,6 @@ module MarkdownRails
   autoload :Handler, 'markdown-rails/handler'
 
   module Renderer
-    class << self
-      def configuration
-        @configuration ||= Configuration.new
-      end
-
-      def configure
-        yield(configuration)
-      end
-    end
-
-    class Configuration
-      attr_accessor :render_options
-
-      def initialize
-        # For option details: https://github.com/vmg/redcarpet?tab=readme-ov-file#darling-i-packed-you-a-couple-renderers-for-lunch
-        @render_options = []
-      end
-    end
     autoload :Base,       'markdown-rails/renderer/base'
     autoload :Rails,      'markdown-rails/renderer/rails'
   end

--- a/lib/markdown-rails.rb
+++ b/lib/markdown-rails.rb
@@ -1,19 +1,37 @@
-require "markdown-rails/version"
-require "markdown-rails/engine"
+require 'markdown-rails/version'
+require 'markdown-rails/engine'
 
 module MarkdownRails
   def self.handle(*extensions, &block)
     Handler.handle(*extensions, &block)
   end
 
-  autoload :Handler,   "markdown-rails/handler"
+  autoload :Handler, 'markdown-rails/handler'
 
   module Renderer
-    autoload :Base,       "markdown-rails/renderer/base"
-    autoload :Rails,      "markdown-rails/renderer/rails"
+    class << self
+      def configuration
+        @configuration ||= Configuration.new
+      end
+
+      def configure
+        yield(configuration)
+      end
+    end
+
+    class Configuration
+      attr_accessor :render_options
+
+      def initialize
+        # For option details: https://github.com/vmg/redcarpet?tab=readme-ov-file#darling-i-packed-you-a-couple-renderers-for-lunch
+        @render_options = []
+      end
+    end
+    autoload :Base,       'markdown-rails/renderer/base'
+    autoload :Rails,      'markdown-rails/renderer/rails'
   end
 
   module Helper
-    autoload :Rouge,      "markdown-rails/helper/rouge"
+    autoload :Rouge,      'markdown-rails/helper/rouge'
   end
 end

--- a/lib/markdown-rails/renderer/base.rb
+++ b/lib/markdown-rails/renderer/base.rb
@@ -1,28 +1,27 @@
-require "redcarpet"
+require 'redcarpet'
 
 module MarkdownRails
   module Renderer
     class Base < Redcarpet::Render::HTML
-      def enable
-        # This is a very restrictive Markdown renderer that errs on the side of safety.
-        # For more details read the docs at https://github.com/vmg/redcarpet#darling-i-packed-you-a-couple-renderer-for-lunch
-        [
-          :filter_html,
-          :no_images,
-          :no_links,
-          :no_styles,
-          :safe_links_only
-        ]
+      def render_options
+        Renderer.configuration.render_options
       end
 
+      def enable; end
+
       def renderer
-        ::Redcarpet::Markdown.new(self.class, **features)
+        ::Redcarpet::Markdown.new(self.class.new(**render_opts), **features)
       end
 
       private
-        def features
-          Hash[Array(enable).map{ |feature| [ feature, true ] }]
-        end
+
+      def render_opts
+        Hash[Array(render_options).map { |opt| [opt, true] }]
+      end
+
+      def features
+        Hash[Array(enable).map { |feature| [feature, true] }]
+      end
     end
   end
 end

--- a/lib/markdown-rails/renderer/base.rb
+++ b/lib/markdown-rails/renderer/base.rb
@@ -3,19 +3,17 @@ require 'redcarpet'
 module MarkdownRails
   module Renderer
     class Base < Redcarpet::Render::HTML
-      def render_options
-        Renderer.configuration.render_options
-      end
+      def render_options; end
 
       def enable; end
 
       def renderer
-        ::Redcarpet::Markdown.new(self.class.new(**render_opts), **features)
+        ::Redcarpet::Markdown.new(self.class.new(**options), **features)
       end
 
       private
 
-      def render_opts
+      def options
         Hash[Array(render_options).map { |opt| [opt, true] }]
       end
 

--- a/lib/markdown-rails/version.rb
+++ b/lib/markdown-rails/version.rb
@@ -1,3 +1,3 @@
 module MarkdownRails
-  VERSION = "2.1.0"
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
## What
Adds a configuration method to enable hooking in via the initializer to configure HTML rendering options.

## Closes
#4 

## Why
I wanted to use `:with_toc_data` and ended up hacking it with `<span id="blah">` because I had to ship, but this change allows users to access HTML rendering options.

### Background/Context
The Base renderer was passing in HTML rendering options as extensions, so they were not working as expected. I realized that we need to set these as options on the renderer rather than on the parser. As a result of this, the options that were previously being set were not actually being respected. I have removed all the previously default options for this reason. My rationale for this choice is that folks already using the Sitepress base renderer probably have come to expect that it behaves in this way, but open to re-adding the restrictive options.

Rendering options are now set via an overrideable method, and the default (commented out method) will set the `:with_toc_data` option. I kept the style of array of symbols that we transform into a hash, and I also bumped the version up by a minor increment, as the change should be mostly backwards compatible but is a new feature. We still allow end users to set up extensions via the `Base.enable` method, so extensions like `:tables` or `:autolinks` should still function.